### PR TITLE
switch to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple PowerShell script to install the NVIDIA Control Panel as a UWP or Win32
 ## Usage
 Use the following command to run the script:
 ```ps
-irm "https://raw.githubusercontent.com/Aetopia/Install-NVCPL/main/Install-NVCPL.ps1" | iex
+irm "https://cdn.jsdelivr.net/gh/Aetopia/Install-NVCPL@main/Install-NVCPL.ps1" | iex
 ```
 
 ## Build NVCPL Launcher


### PR DESCRIPTION
https://www.jsdelivr.com/github

> By using jsDelivr CDN URLs you get better performance globally thanks to our multi-CDN infrastructure. We also permanently cache all files to ensure reliability, even if your files get deleted from Github they will continue to work on jsDelivr without breaking any sites using them. The jsDelivr CDN is designed for production use with multiple layers of failover to ensure best possible uptime.